### PR TITLE
Added ctrl+e and ctrl+r navigation in login and menu page

### DIFF
--- a/src/pages/login.page.c
+++ b/src/pages/login.page.c
@@ -183,8 +183,23 @@ void PageHandler_login(p_obj pArgs_Page) {
 
           // Switch fields
           case '\t':
-            Page_setUserState(this, "login-current-field", ((int) cLoginCurrentField + 1) % (int) cLoginFieldCount);
-          break;
+          // ctrl+k lol
+          case 5:
+            Page_setUserState(this, "login-current-field", ((int)cLoginCurrentField + 1) % (int)cLoginFieldCount);
+            break;
+
+          // ctrl+w lol
+          case 18:
+          {
+            int previous = ((int)cLoginCurrentField) - 1;
+            Page_setUserState(
+              this,
+              "login-current-field",
+              previous < 0 ?
+                ((int)cLoginFieldCount) - 1
+                  : previous
+            );
+          } break;
 
           // Do input checking, then go to menu if successful
           case '\n': case '\r': case 27:
@@ -210,7 +225,7 @@ void PageHandler_login(p_obj pArgs_Page) {
                 // Deleting account tho
                 if(cKeyPressed == 27) {
                   Page_enableComponentPopup(this, sPopupComponent);
-                  Page_setComponentPopupText(this, sPopupComponent, "Are.you.sure.you.want.to.delete.the.profile?\nThis.action.cannot.be.undone.");
+                  Page_setComponentPopupText(this, sPopupComponent, "Are you sure you want to delete the profile?\nThis action cannot be undone.");
                   Page_setComponentPopupOptions(this, sPopupComponent, "yes", "no.", "secondary", "accent");
                   Page_setUserState(this, "popup-action", 0);
                   
@@ -235,7 +250,7 @@ void PageHandler_login(p_obj pArgs_Page) {
                 // Create a new account perhaps?
                 if(Profile_getErrorId(pProfile) == PROFILE_ERROR_NOT_FOUND && cKeyPressed != 27) {
                   Page_enableComponentPopup(this, sPopupComponent);
-                  Page_setComponentPopupText(this, sPopupComponent, "This.account.does.not.yet.exist.\nWould.you.like.to.register.it?");
+                  Page_setComponentPopupText(this, sPopupComponent, "This account does not yet exist\nWould you like to register it?");
                   Page_setComponentPopupOptions(this, sPopupComponent, "yes", "no.", "secondary", "accent");
                   Page_setUserState(this, "popup-action", 1);
                 }

--- a/src/pages/menu.page.c
+++ b/src/pages/menu.page.c
@@ -119,8 +119,23 @@ void PageHandler_menu(p_obj pArgs_Page) {
 
         // Increment menu selector
         case '\t':
+        // ctrl+e lol
+        case 5:
           Page_setUserState(this, "menu-selector", ((int) cMenuSelector + 1) % dMenuSelectorLength);
-        break;
+          break;
+
+        // ctrl+w lol
+        case 18:
+        {
+          int previous = ((int)cMenuSelector) - 1;
+          Page_setUserState(
+            this,
+            "menu-selector",
+            previous < 0 ?
+              ((int)dMenuSelectorLength) - 1 
+              : previous
+          );
+        } break;
 
         // Move to page
         case '\n': case '\r':


### PR DESCRIPTION
Hi, guys!

Would just like to drop by and say good job to your MP! :confetti_ball:

The code is overkill and pushes the capabilities of the console/terminal a bit too much, but still impressive nonetheless.

As a sign of respect AND for a bit of banter from one programmer to another, here's a pull request that adds additional navigation options to the user.

in the login and main menu pages the user can press:
**ctrl+e** - To **E**ngage / Move forward
**ctrl+r** - To **R**everse / Move backwards

See video below to view the changes in action

[Screencast from 14-04-24 01 31 37.webm](https://github.com/MoDavid1964/Minesweeper-in-C/assets/127288337/4275cf2c-609f-463f-8e85-23fb94486d42)

Now. Why ctrl+e and ctrl+r instead of arrow keys?  It just felt funny. 
But mostly because the terminal wasn't made to become a GUI. 
At least in Linux, there are extra characters being processed when arrow keys are used.

Kudos :+1: :cake:


Extra bonus tip: Also removed the.dots.per.character. In the popups of the login menu :wink:

![image](https://github.com/MoDavid1964/Minesweeper-in-C/assets/127288337/814269ca-ffeb-4420-a89b-e4a213d4719e)
